### PR TITLE
added Docker RUN command in streamlit Dockerfile

### DIFF
--- a/streamlit/Dockerfile
+++ b/streamlit/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.10
 
 WORKDIR /code
 
+RUN apt-get update && apt-get install ffmpeg libsm6 libxext6 -y
+
 COPY requirements.txt /code
 RUN pip install -r requirements.txt
 


### PR DESCRIPTION
Upon running 'docker compose up --build' there was an error the first time concerning opencv: 'ImportError: libGL.so.1: cannot open shared object file: No such file or directory '.

The solution to this bug in my case was to add 'RUN apt-get update && apt-get install ffmpeg libsm6 libxext6 -y' between the lines 'WORKDIR /code' and 'COPY requirements.txt /code' in the Dockerfile of the Streamlit folder.